### PR TITLE
Add support for multiple amplifier devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ You can install this either manually copying files or using HACS. Configuration 
 - Password: Use the same password you configured via Administrator Settings on the amplifier
 - Scan Interval: how often you want Home Assistant to fetch values from the amplifier
 
+### Requirements
+- Minimum Juke firmware version 4.2.1
+
 Usage
 =====
 
-This integration creates Media Player entities for each of the amplifier zones, Select entities for the different inputs, and diagnostic sensors for monitoring hardware and network. For each zone you can control the Juke source it is mapped to and volume. You can use the Input entities to switch between different input types supported by your Juke.
+This integration creates Media Player entities for each of the amplifier zones and inputs, and diagnostic sensors for monitoring hardware and network. For each zone you can control the Juke source it is mapped to and volume. You can use the Input entities to switch between different input types supported by your Juke.

--- a/custom_components/jukeaudio_ha/manifest.json
+++ b/custom_components/jukeaudio_ha/manifest.json
@@ -12,8 +12,8 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/pkarimov/jukeaudio_ha/issues",
   "loggers": ["jukeaudio"],
-  "requirements": ["jukeaudio==0.0.10"],
+  "requirements": ["jukeaudio==0.0.11"],
   "ssdp": [],
-  "version": "0.0.1",
+  "version": "0.0.10",
   "zeroconf": []
 }

--- a/custom_components/jukeaudio_ha/media_player.py
+++ b/custom_components/jukeaudio_ha/media_player.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, LOGGER
-from .hub import JukeAudioHub
+from .hub import JukeAudioHub, JukeAudioDevice
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -25,26 +25,23 @@ async def async_setup_entry(
     hub: JukeAudioHub = hass.data[DOMAIN][config_entry.entry_id]["hub"]
     coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
 
-    entities = []
-    # Add zone entities
-    for zone in hub.zones:
-        entities.append(
-            Zone(hub, coordinator, config_entry, hub.zones[zone]["zone_id"])
-        )
-    
-    # Add input entities
-    if hub.useV3:
-        for i in hub.inputs:
-            if hub.inputs[i]["input_class"] == 0:
-                entities.append(
-                    InputMediaPlayer(hub, coordinator, config_entry, hub.inputs[i]["input_id"])
-                )
-    else:
-        for i in hub.inputs:
+    entities = []    
+    for juke_id in hub.jukes:
+        juke = hub.jukes[juke_id]
+
+        # Add zone entities
+        for zone_id in juke.zones:
             entities.append(
-                InputMediaPlayer(hub, coordinator, config_entry, hub.inputs[i]["input_id"])
+                Zone(juke, coordinator, config_entry, zone_id)
             )
 
+        # Add input entities    
+        for input_id in juke.inputs:
+            input = juke.inputs[input_id]
+            if input["input_class"] == 0:
+                entities.append(
+                    InputMediaPlayer(juke, coordinator, config_entry, input_id)
+                )
     if entities:
         async_add_entities(entities)
 
@@ -54,17 +51,17 @@ class JukeAudioMediaPlayerBase(CoordinatorEntity, MediaPlayerEntity):
 
     _attr_has_entity_name = True
 
-    def __init__(self, hub: JukeAudioHub, coordinator, config_entry) -> None:
+    def __init__(self, juke: JukeAudioDevice, coordinator, config_entry) -> None:
         """Initialize the sensor."""
         super().__init__(
             coordinator,
         )
-        self._hub = hub
+        self._juke = juke
         self._config_entry = config_entry
 
     @property
     def device_info(self) -> DeviceInfo:
-        return self._hub.juke.device_info
+        return self._juke.device_info
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -76,9 +73,9 @@ class Zone(JukeAudioMediaPlayerBase):
 
     device_class = MediaPlayerDeviceClass.SPEAKER
 
-    def __init__(self, hub: JukeAudioHub, coordinator, config_entry, zone_id) -> None:
+    def __init__(self, juke: JukeAudioDevice, coordinator, config_entry, zone_id) -> None:
         """Initialize the sensor."""
-        super().__init__(hub, coordinator, config_entry)
+        super().__init__(juke, coordinator, config_entry)
         self._zone_id = zone_id
 
     @property
@@ -87,14 +84,14 @@ class Zone(JukeAudioMediaPlayerBase):
 
     @property
     def name(self) -> str:
-        return f'{self._hub.zones[self._zone_id]["name"]} Zone'
+        return f'{self._juke.zones[self._zone_id]["name"]} Zone'
 
     @property
     def extra_state_attributes(self):
         """Return additional attributes for the zone."""
         attributes = {}
         
-        zone_data = self._hub.zones[self._zone_id]
+        zone_data = self._juke.zones[self._zone_id]
         
         # Add warning messages as attributes if present
         if "warnings" in zone_data and zone_data["warnings"]:
@@ -107,7 +104,7 @@ class Zone(JukeAudioMediaPlayerBase):
     def state(self) -> MediaPlayerState | None:
         """State of the player."""
         # Check if there's an active input for this zone
-        zone_data = self._hub.zones[self._zone_id]
+        zone_data = self._juke.zones[self._zone_id]
         
         # If zone has an active_input that's not None, it's playing
         if "active_input" in zone_data and zone_data["active_input"] is not None:
@@ -123,28 +120,24 @@ class Zone(JukeAudioMediaPlayerBase):
     @property
     def media_title(self) -> str | None:
         """Title of current playing media."""
-        zone_data = self._hub.zones[self._zone_id]
+        zone_data = self._juke.zones[self._zone_id]
         
         # Only provide title if we're playing
         if "active_input" in zone_data and zone_data["active_input"] is not None:
             active_input_id = zone_data["active_input"]
             
             # Get the name of the active input
-            if active_input_id in self._hub.inputs:
-                input_data = self._hub.inputs[active_input_id]
+            if active_input_id in self._juke.inputs:
+                input_data = self._juke.inputs[active_input_id]
                 
                 # Only use input name if input class is 0
-                if self._hub.useV3 and input_data.get("input_class") == 0:
-                    input_name = input_data.get("name")
-                    if input_name:
-                        return f"Playing from {input_name}"
-                elif not self._hub.useV3:  # For non-V3, use input name directly
+                if input_data.get("input_class") == 0:
                     input_name = input_data.get("name")
                     if input_name:
                         return f"Playing from {input_name}"
                 
                 # If we can't use the name, fall back to type
-                input_type = input_data.get("input_type" if self._hub.useV3 else "type", "Unknown")
+                input_type = input_data.get("input_type", "Unknown")
                 return f"Playing from {input_type}"
                 
         return None
@@ -158,7 +151,7 @@ class Zone(JukeAudioMediaPlayerBase):
     
     @property 
     def icon(self) -> str | None:
-        zone_data = self._hub.zones[self._zone_id]
+        zone_data = self._juke.zones[self._zone_id]
         
         # Show warning icon if there are warnings
         if "warnings" in zone_data and zone_data["warnings"]:
@@ -183,39 +176,29 @@ class Zone(JukeAudioMediaPlayerBase):
     @property
     def volume_level(self) -> float | None:
         """Volume level of the media player (0..1)."""
-        return float(self._hub.zones[self._zone_id]["volume"]) / 100.0
+        return float(self._juke.zones[self._zone_id]["volume"]) / 100.0
 
     @property
     def source_list(self) -> list[str]:
         """List of available input sources."""
         sources = ["None"]
 
-        if self._hub.useV3:
-            for i in self._hub.inputs:
-                # Only show enabled inputs
-                if (self._hub.inputs[i]["input_class"] == 0 and 
-                    self._hub.inputs[i].get("enabled", True)):
-                    sources.append(self._hub.inputs[i]["name"])
-        else:
-            for i in self._hub.inputs:
-                # Only show enabled inputs
-                if self._hub.inputs[i].get("enabled", True):
-                    sources.append(self._hub.inputs[i]["name"])
+        for i in self._juke.inputs:
+            # Only show enabled inputs
+            if (self._juke.inputs[i]["input_class"] == 0 and 
+                self._juke.inputs[i].get("enabled", True)):
+                sources.append(self._juke.inputs[i]["name"])
 
         return sources
 
     @property
     def source(self) -> str:
         """Currently selected input source"""
-        zone_inputs = self._hub.zones[self._zone_id]["input"]
+        zone_inputs = self._juke.zones[self._zone_id]["input"]
 
-        if self._hub.useV3:
-            for input_id in zone_inputs:
-                if input_id in self._hub.inputs and self._hub.inputs[input_id]["input_class"] == 0:
-                    return self._hub.inputs[input_id]["name"]
-        else:
-            if len(zone_inputs) > 0 and zone_inputs[0] in self._hub.inputs:
-                return self._hub.inputs[zone_inputs[0]]["name"]
+        for input_id in zone_inputs:
+            if input_id in self._juke.inputs and self._juke.inputs[input_id]["input_class"] == 0:
+                return self._juke.inputs[input_id]["name"]
 
         return "None"
 
@@ -227,20 +210,20 @@ class Zone(JukeAudioMediaPlayerBase):
     async def async_set_volume_level(self, volume):
         """Set volume level, range 0..1."""
         LOGGER.debug("Setting volume to %s for zone %s", volume, self._zone_id)
-        await self._hub.set_zone_volume(self._zone_id, int(volume*100))
+        await self._juke.hub.set_zone_volume(self._zone_id, int(volume*100))
         await self.async_update()
 
     async def async_select_source(self, source: str):
         """Select input source."""
 
         input_id = None
-        for i in self._hub.inputs:
-            if self._hub.inputs[i]["name"] == source:
-                input_id = self._hub.inputs[i]["input_id"]
+        for i in self._juke.inputs:
+            if self._juke.inputs[i]["name"] == source:
+                input_id = self._juke.inputs[i]["input_id"]
                 break
 
         LOGGER.debug("Setting input to %s for zone %s", input_id, self._zone_id)
-        await self._hub.set_zone_input(self._zone_id, input_id)
+        await self._juke.hub.set_zone_input(self._zone_id, input_id)
         await self.async_update()
 
 
@@ -249,9 +232,9 @@ class InputMediaPlayer(JukeAudioMediaPlayerBase):
     
     device_class = MediaPlayerDeviceClass.RECEIVER
     
-    def __init__(self, hub: JukeAudioHub, coordinator, config_entry, input_id) -> None:
+    def __init__(self, juke: JukeAudioDevice, coordinator, config_entry, input_id) -> None:
         """Initialize the input media player."""
-        super().__init__(hub, coordinator, config_entry)
+        super().__init__(juke, coordinator, config_entry)
         self._input_id = input_id
     
     @property
@@ -260,7 +243,7 @@ class InputMediaPlayer(JukeAudioMediaPlayerBase):
     
     @property
     def name(self) -> str:
-        return f"{self._hub.inputs[self._input_id]['name']} Input"
+        return f"{self._juke.inputs[self._input_id]['name']} Input"
     
     @property
     def supported_features(self) -> MediaPlayerEntityFeature:
@@ -268,7 +251,7 @@ class InputMediaPlayer(JukeAudioMediaPlayerBase):
         features = MediaPlayerEntityFeature.SELECT_SOURCE | MediaPlayerEntityFeature.TURN_ON | MediaPlayerEntityFeature.TURN_OFF
         
         # Only add volume control if volume exists for this input
-        input_data = self._hub.inputs[self._input_id]
+        input_data = self._juke.inputs[self._input_id]
         if "volume" in input_data and input_data["volume"] is not None:
             features |= MediaPlayerEntityFeature.VOLUME_SET
             
@@ -277,7 +260,7 @@ class InputMediaPlayer(JukeAudioMediaPlayerBase):
     @property
     def state(self) -> MediaPlayerState | None:
         """State of the player."""
-        input_data = self._hub.inputs[self._input_id]
+        input_data = self._juke.inputs[self._input_id]
         # Check if input is enabled, defaulting to True if not present
         if input_data.get("enabled", True):
             return MediaPlayerState.ON
@@ -287,7 +270,7 @@ class InputMediaPlayer(JukeAudioMediaPlayerBase):
     @property
     def volume_level(self) -> float | None:
         """Volume level of the media player (0..1)."""
-        input_data = self._hub.inputs[self._input_id]
+        input_data = self._juke.inputs[self._input_id]
         if "volume" in input_data and input_data["volume"] is not None:
             return float(input_data["volume"]) / 100.0
         return None
@@ -295,15 +278,12 @@ class InputMediaPlayer(JukeAudioMediaPlayerBase):
     @property
     def source(self) -> str:
         """Currently selected input type."""
-        if self._hub.useV3:
-            return self._hub.inputs[self._input_id]["input_type"]
-        else:
-            return self._hub.inputs[self._input_id]["type"]
+        return self._juke.inputs[self._input_id]["input_type"]
     
     @property
     def source_list(self) -> list[str]:
         """List of available input types."""
-        available_types = self._hub.inputs[self._input_id]["available_types"]
+        available_types = self._juke.inputs[self._input_id]["available_types"]
         
         # Get current source by using the source property
         current_source = self.source
@@ -337,23 +317,23 @@ class InputMediaPlayer(JukeAudioMediaPlayerBase):
     async def async_set_volume_level(self, volume):
         """Set volume level, range 0..1."""
         LOGGER.debug("Setting volume to %s for input %s", volume, self._input_id)
-        await self._hub.set_input_volume(self._input_id, int(volume*100))
+        await self._juke.hub.set_input_volume(self._input_id, int(volume*100))
         await self.async_update()
     
     async def async_select_source(self, source: str):
         """Select input type."""
         LOGGER.debug("Setting input type to %s for input %s", source, self._input_id)
-        await self._hub.set_input_type(self._input_id, source)
+        await self._juke.hub.set_input_type(self._input_id, source)
         await self.async_update()
     
     async def async_turn_on(self) -> None:
         """Turn the input on (enable it)."""
         LOGGER.debug("Enabling input %s", self._input_id)
-        await self._hub.set_input_enabled(self._input_id, True)
+        await self._juke.hub.set_input_enabled(self._input_id, True)
         await self.async_update()
     
     async def async_turn_off(self) -> None:
         """Turn the input off (disable it)."""
         LOGGER.debug("Disabling input %s", self._input_id)
-        await self._hub.set_input_enabled(self._input_id, False)
+        await self._juke.hub.set_input_enabled(self._input_id, False)
         await self.async_update()

--- a/custom_components/jukeaudio_ha/sensor.py
+++ b/custom_components/jukeaudio_ha/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .hub import JukeAudioHub
+from .hub import JukeAudioHub, JukeAudioDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,13 +31,15 @@ async def async_setup_entry(
 
     entities = []
 
-    entities.append(SignalStrength(hub, coordinator, config_entry))
-    entities.append(ConnectionType(hub, coordinator, config_entry))
-    entities.append(SSID(hub, coordinator, config_entry))
-    entities.append(Uptime(hub, coordinator, config_entry))
-    entities.append(CpuUsage(hub, coordinator, config_entry))
-    entities.append(DiskUsage(hub, coordinator, config_entry))
-    entities.append(RamUsage(hub, coordinator, config_entry))
+    for juke_id in hub.jukes:
+        juke = hub.jukes[juke_id]
+        entities.append(SignalStrength(juke, coordinator, config_entry))
+        entities.append(ConnectionType(juke, coordinator, config_entry))
+        entities.append(SSID(juke, coordinator, config_entry))
+        entities.append(Uptime(juke, coordinator, config_entry))
+        entities.append(CpuUsage(juke, coordinator, config_entry))
+        entities.append(DiskUsage(juke, coordinator, config_entry))
+        entities.append(RamUsage(juke, coordinator, config_entry))
 
     if entities:
         async_add_entities(entities)
@@ -48,17 +50,17 @@ class JukeAudioSensorBase(CoordinatorEntity, SensorEntity):
 
     _attr_has_entity_name = True
 
-    def __init__(self, hub: JukeAudioHub, coordinator, config_entry) -> None:
+    def __init__(self, juke: JukeAudioDevice, coordinator, config_entry) -> None:
         """Initialize the sensor."""
         super().__init__(
             coordinator,
         )
-        self._hub = hub
+        self._juke = juke
         self._config_entry = config_entry
 
     @property
     def device_info(self) -> DeviceInfo:
-        return self._hub.juke.device_info
+        return self._juke.device_info
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -76,13 +78,13 @@ class SignalStrength(JukeAudioSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._hub.juke.uid_base}_signal_strength"
+        return f"{self._juke.uid_base}_signal_strength"
 
     @property
     def native_value(self):
-        if self._hub.juke.connection_info is None:
+        if self._juke.connection_info is None:
             return None
-        return self._hub.juke.connection_info["signal_strength"]
+        return self._juke.connection_info["signal_strength"]
 
     @property
     def name(self) -> str:
@@ -97,13 +99,13 @@ class ConnectionType(JukeAudioSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._hub.juke.uid_base}_connection_type"
+        return f"{self._juke.uid_base}_connection_type"
 
     @property
     def native_value(self):
-        if self._hub.juke.connection_info is None:
+        if self._juke.connection_info is None:
             return None
-        return self._hub.juke.connection_info["type"]
+        return self._juke.connection_info["type"]
 
     @property
     def name(self) -> str:
@@ -118,13 +120,13 @@ class SSID(JukeAudioSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._hub.juke.uid_base}_ssid"
+        return f"{self._juke.uid_base}_ssid"
 
     @property
     def native_value(self):
-        if self._hub.juke.connection_info is None:
+        if self._juke.connection_info is None:
             return None
-        return self._hub.juke.connection_info["ssid"]
+        return self._juke.connection_info["ssid"]
 
     @property
     def name(self) -> str:
@@ -140,13 +142,13 @@ class Uptime(JukeAudioSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._hub.juke.uid_base}_uptime"
+        return f"{self._juke.uid_base}_uptime"
 
     @property
     def native_value(self):
-        if self._hub.juke.connection_info is None:
+        if self._juke.connection_info is None:
             return None
-        return self._hub.juke.connection_info["uptime"]
+        return self._juke.connection_info["uptime"]
 
     @property
     def name(self) -> str:
@@ -161,13 +163,13 @@ class CpuUsage(JukeAudioSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._hub.juke.uid_base}_cpu_usage"
+        return f"{self._juke.uid_base}_cpu_usage"
 
     @property
     def native_value(self):
-        if self._hub.juke.device_metrics is None:
+        if self._juke.device_metrics is None:
             return None
-        return self._hub.juke.device_metrics["cpu_usage"]
+        return self._juke.device_metrics["cpu_usage"]
 
     @property
     def name(self) -> str:
@@ -182,13 +184,13 @@ class DiskUsage(JukeAudioSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._hub.juke.uid_base}_disk_usage"
+        return f"{self._juke.uid_base}_disk_usage"
 
     @property
     def native_value(self):
-        if self._hub.juke.device_metrics is None:
+        if self._juke.device_metrics is None:
             return None
-        return self._hub.juke.device_metrics["disk_usage"]
+        return self._juke.device_metrics["disk_usage"]
 
     @property
     def name(self) -> str:
@@ -203,13 +205,13 @@ class RamUsage(JukeAudioSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._hub.juke.uid_base}_ram_usage"
+        return f"{self._juke.uid_base}_ram_usage"
 
     @property
     def native_value(self):
-        if self._hub.juke.device_metrics is None:
+        if self._juke.device_metrics is None:
             return None
-        return self._hub.juke.device_metrics["ram_usage"]
+        return self._juke.device_metrics["ram_usage"]
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
This pull request introduces significant updates to the Juke Audio integration for Home Assistant, focusing on support for multiple Juke devices, improved handling of device-specific data, and codebase simplification. The changes replace the previous single-device model with a multi-device approach, refactor the code to remove outdated methods, and update dependencies to ensure compatibility with the latest Juke firmware.

### Multi-device support and refactoring:

* [`custom_components/jukeaudio_ha/hub.py`](diffhunk://#diff-ee6091265cf444e1de72b3e3aafc18f9366ccdf73fc89680f454dbdfa96d0ff0L25-R55): Refactored the hub logic to support multiple Juke devices (`jukes` dictionary), replacing the single-device model. Removed outdated methods and added new methods for fetching device-specific data, such as `_get_devices_info`, `_get_zones_info`, and `_get_input_info`.
* [`custom_components/jukeaudio_ha/media_player.py`](diffhunk://#diff-abb9051b5e77df33eac57a8e9b3aa256989b24144c99ba832f17d60f9e59b34aR29-L47): Updated media player entities (`Zone` and `InputMediaPlayer`) to work with individual Juke devices instead of the hub. Replaced references to `hub` with `juke` and removed conditional logic for V3 compatibility. 

### Dependency updates:

* [`custom_components/jukeaudio_ha/manifest.json`](diffhunk://#diff-63ed3dba0a8e1e656370911a51fd1b26bc3a0b05be8cfe180122254934574e88L15-R17): Updated the `jukeaudio` library version from `0.0.10` to `0.0.11` and incremented the integration version to `0.0.10`.

### Documentation improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R27-R33): Added a "Requirements" section specifying the minimum Juke firmware version (4.2.1) and updated descriptions to reflect changes in supported entities.

These changes enhance the scalability and maintainability of the integration while ensuring compatibility with newer firmware versions.